### PR TITLE
Backend initialised by JanusGraphFactory

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-Please replace every line in curly brackets ( { like this } ) with an appropriate description, and remove this line.
-
 ## What is the goal of this PR?
 
 { In the form of a paragraph (only use bullet points if strictly necessary), please describe the goal of this PR, why they are valuable to achieve, and reference the related GitHub issues. This section will be automatically compiled into the release notes, so please:

--- a/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/ConfiguredGraphFactory.java
@@ -73,21 +73,21 @@ public class ConfiguredGraphFactory {
      *
      * @return JanusGraph
      */
-    public static synchronized JanusGraph create(final String graphName) {
-        final ConfigurationManagementGraph configManagementGraph = getConfigGraphManagementInstance();
+    public static synchronized JanusGraph create(String graphName) {
+        ConfigurationManagementGraph configManagementGraph = getConfigGraphManagementInstance();
 
-        final Map<String, Object> graphConfigMap = configManagementGraph.getConfiguration(graphName);
+        Map<String, Object> graphConfigMap = configManagementGraph.getConfiguration(graphName);
         Preconditions.checkState(null == graphConfigMap, String.format("Configuration for graph %s already exists.", graphName));
-        final Map<String, Object> templateConfigMap = configManagementGraph.getTemplateConfiguration();
+        Map<String, Object> templateConfigMap = configManagementGraph.getTemplateConfiguration();
         Preconditions.checkNotNull(templateConfigMap,
                                 "Please create a template Configuration using the ConfigurationManagementGraph#createTemplateConfiguration API.");
         templateConfigMap.put(ConfigurationManagementGraph.PROPERTY_GRAPH_NAME, graphName);
         templateConfigMap.put(ConfigurationManagementGraph.PROPERTY_CREATED_USING_TEMPLATE, true);
 
-        final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
+        JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
         Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
-        final CommonsConfiguration config = new CommonsConfiguration(new MapConfiguration(templateConfigMap));
-        final JanusGraph g = (JanusGraph) jgm.openGraph(graphName, (String gName) -> new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(config)));
+        MapConfiguration mapConfiguration = new MapConfiguration(templateConfigMap);
+        JanusGraph g = (JanusGraph) jgm.openGraph(graphName, (String gName) -> JanusGraphFactory.open(mapConfiguration));
         configManagementGraph.createConfiguration(new MapConfiguration(templateConfigMap));
         return g;
     }
@@ -111,8 +111,8 @@ public class ConfiguredGraphFactory {
                                 "Please create configuration for this graph using the ConfigurationManagementGraph#createConfiguration API.");
         final JanusGraphManager jgm = JanusGraphManagerUtility.getInstance();
         Preconditions.checkNotNull(jgm, JANUS_GRAPH_MANAGER_EXPECTED_STATE_MSG);
-        final CommonsConfiguration config = new CommonsConfiguration(new MapConfiguration(graphConfigMap));
-        return (JanusGraph) jgm.openGraph(graphName, (String gName) -> new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(config)));
+        MapConfiguration mapConfiguration = new MapConfiguration(graphConfigMap);
+        return (JanusGraph) jgm.openGraph(graphName, (String gName) -> JanusGraphFactory.open(mapConfiguration));
     }
 
     /**

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -1190,8 +1190,8 @@ public class GraphDatabaseConfiguration {
 
     private final Configuration configuration;
     private final ReadConfiguration configurationAtOpen;
-    private String uniqueGraphId;
-    private final ModifiableConfiguration localConfiguration;
+    private final String uniqueGraphId;
+    private StoreFeatures storeFeatures;
 
     private boolean readOnly;
     private boolean flushIDs;
@@ -1210,14 +1210,12 @@ public class GraphDatabaseConfiguration {
     private String metricsPrefix;
     private String unknownIndexKeyName;
 
-    private StoreFeatures storeFeatures = null;
 
-    public GraphDatabaseConfiguration(ReadConfiguration configurationAtOpen, ModifiableConfiguration localConfiguration,
-                                      String uniqueGraphId, Configuration configuration) {
+    public GraphDatabaseConfiguration(ReadConfiguration configurationAtOpen, String uniqueGraphId, Configuration configuration, StoreFeatures storeFeatures) {
         this.configurationAtOpen = configurationAtOpen;
-        this.localConfiguration = localConfiguration;
         this.uniqueGraphId = uniqueGraphId;
         this.configuration = configuration;
+        this.storeFeatures = storeFeatures;
         preLoadConfiguration();
     }
 
@@ -1332,18 +1330,11 @@ public class GraphDatabaseConfiguration {
         return configuration;
     }
 
-    public Backend getBackend() {
-        Backend backend = new Backend(configuration);
-        storeFeatures = backend.getStoreFeatures();
-        return backend;
-    }
-
     public String getGraphName() {
         return getConfigurationAtOpen().getString(GRAPH_NAME.toStringWithoutRoot());
     }
 
     public StoreFeatures getStoreFeatures() {
-        Preconditions.checkArgument(storeFeatures != null, "Cannot retrieve store features before the storage backend has been initialized");
         return storeFeatures;
     }
 
@@ -1366,12 +1357,6 @@ public class GraphDatabaseConfiguration {
     public SchemaCache getTypeCache(SchemaCache.StoreRetrieval retriever) {
         if (configuration.get(BASIC_METRICS)) return new MetricInstrumentedSchemaCache(retriever);
         else return new StandardSchemaCache(retriever);
-    }
-
-    public org.apache.commons.configuration.Configuration getLocalConfiguration() {
-        org.apache.commons.configuration.Configuration config = ((CommonsConfiguration)localConfiguration.getConfiguration()).getCommonConfiguration();
-        config.setProperty(Graph.GRAPH, JanusGraphFactory.class.getName());
-        return config;
     }
 
     public org.apache.commons.configuration.Configuration getConfigurationAtOpen() {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -1191,7 +1191,7 @@ public class GraphDatabaseConfiguration {
     private final Configuration configuration;
     private final ReadConfiguration configurationAtOpen;
     private final String uniqueGraphId;
-    private StoreFeatures storeFeatures;
+    private final StoreFeatures storeFeatures;
 
     private boolean readOnly;
     private boolean flushIDs;

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/builder/GraphDatabaseConfigurationBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/builder/GraphDatabaseConfigurationBuilder.java
@@ -40,7 +40,7 @@ import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.*;
  */
 public class GraphDatabaseConfigurationBuilder {
 
-    public GraphDatabaseConfiguration build(ReadConfiguration localConfig){
+    public static GraphDatabaseConfiguration build(ReadConfiguration localConfig){
 
         Preconditions.checkNotNull(localConfig);
 
@@ -69,17 +69,17 @@ public class GraphDatabaseConfigurationBuilder {
 
         MergedConfiguration configuration = new MergedConfiguration(overwrite,combinedConfig);
 
-        return new GraphDatabaseConfiguration(localConfig, localConfiguration, uniqueGraphId, configuration);
+        return new GraphDatabaseConfiguration(localConfig, uniqueGraphId, configuration, storeFeatures);
     }
 
-    private Map<ConfigElement.PathIdentifier, Object> getLocalSubset(Map<ConfigElement.PathIdentifier, Object> m) {
+    private static Map<ConfigElement.PathIdentifier, Object> getLocalSubset(Map<ConfigElement.PathIdentifier, Object> m) {
         return Maps.filterEntries(m, entry -> {
             assert entry.getKey().element.isOption();
             return ((ConfigOption)entry.getKey().element).isLocal();
         });
     }
 
-    private void checkAndOverwriteTransactionLogConfiguration(Configuration combinedConfig, ModifiableConfiguration overwrite, StoreFeatures storeFeatures){
+    private static void checkAndOverwriteTransactionLogConfiguration(Configuration combinedConfig, ModifiableConfiguration overwrite, StoreFeatures storeFeatures){
 
         //Default log configuration for system and tx log
         //TRANSACTION LOG: send_delay=0, ttl=2days and backend=default
@@ -93,7 +93,7 @@ public class GraphDatabaseConfigurationBuilder {
         }
     }
 
-    private void checkAndOverwriteSystemManagementLogConfiguration(Configuration combinedConfig, ModifiableConfiguration overwrite){
+    private static void checkAndOverwriteSystemManagementLogConfiguration(Configuration combinedConfig, ModifiableConfiguration overwrite){
 
         //SYSTEM MANAGEMENT LOG: backend=default and send_delay=0 and key_consistent=true and fixed-partitions=true
         Preconditions.checkArgument(combinedConfig.get(LOG_BACKEND,MANAGEMENT_LOG).equals(LOG_BACKEND.getDefaultValue()),

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/StandardJanusGraph.java
@@ -158,7 +158,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
 
     private final String name;
 
-    public StandardJanusGraph(GraphDatabaseConfiguration configuration) {
+    public StandardJanusGraph(GraphDatabaseConfiguration configuration, Backend backend) {
 
         this.config = configuration;
         this.name = configuration.getGraphName();
@@ -167,7 +167,7 @@ public class StandardJanusGraph extends JanusGraphBlueprintsGraph {
         this.openTransactions = Collections.newSetFromMap(new ConcurrentHashMap<>(100, 0.75f, 1));
 
         // Collaborators:
-        this.backend = configuration.getBackend();
+        this.backend = backend;
         this.idAssigner = config.getIDAssigner(backend);
         this.idManager = idAssigner.getIDManager();
         this.times = configuration.getTimestampProvider();

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/GraphDatabaseConfigurationInstanceIdTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/GraphDatabaseConfigurationInstanceIdTest.java
@@ -14,23 +14,24 @@
 
 package org.janusgraph.graphdb;
 
-import java.net.Inet4Address;
-import java.net.UnknownHostException;
-import java.util.Map;
-import java.util.HashMap;
 import org.apache.commons.configuration.MapConfiguration;
 import org.janusgraph.core.JanusGraphException;
-import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
-import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
+import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.junit.jupiter.api.Test;
+
+import java.net.Inet4Address;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.REPLACE_INSTANCE_IF_EXISTS;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.UNIQUE_INSTANCE_ID;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.UNIQUE_INSTANCE_ID_HOSTNAME;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.UNIQUE_INSTANCE_ID_SUFFIX;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GraphDatabaseConfigurationInstanceIdTest {
 
@@ -41,17 +42,17 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         map.put(UNIQUE_INSTANCE_ID.toStringWithoutRoot(), "not-unique");
         map.put(REPLACE_INSTANCE_IF_EXISTS.toStringWithoutRoot(), true);
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph1 = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph1 = JanusGraphFactory.open(config);
 
-        assertEquals(graph1.openManagement().getOpenInstances().size(), 1);
-        assertEquals(graph1.openManagement().getOpenInstances().toArray()[0], "not-unique");
+        assertEquals(1, graph1.openManagement().getOpenInstances().size());
+        assertEquals("not-unique", graph1.openManagement().getOpenInstances().toArray()[0]);
 
-        final StandardJanusGraph graph2 = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph2 = JanusGraphFactory.open(config);
 
-        assertEquals(graph1.openManagement().getOpenInstances().size(), 1);
-        assertEquals(graph1.openManagement().getOpenInstances().toArray()[0], "not-unique");
-        assertEquals(graph2.openManagement().getOpenInstances().size(), 1);
-        assertEquals(graph2.openManagement().getOpenInstances().toArray()[0], "not-unique");
+        assertEquals(1, graph1.openManagement().getOpenInstances().size());
+        assertEquals("not-unique", graph1.openManagement().getOpenInstances().toArray()[0]);
+        assertEquals(1, graph2.openManagement().getOpenInstances().size());
+        assertEquals("not-unique", graph2.openManagement().getOpenInstances().toArray()[0]);
         graph1.close();
         graph2.close();
     }
@@ -62,12 +63,12 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(UNIQUE_INSTANCE_ID.toStringWithoutRoot(), "not-unique");
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph1 = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph1 = JanusGraphFactory.open(config);
 
-        assertEquals(graph1.openManagement().getOpenInstances().size(), 1);
-        assertEquals(graph1.openManagement().getOpenInstances().toArray()[0], "not-unique");
+        assertEquals(1, graph1.openManagement().getOpenInstances().size());
+        assertEquals("not-unique", graph1.openManagement().getOpenInstances().toArray()[0]);
         JanusGraphException janusGraphException = assertThrows(JanusGraphException.class, () -> {
-            final StandardJanusGraph graph2 = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+            final StandardJanusGraph graph2 = JanusGraphFactory.open(config);
             graph1.close();
         });
         assertEquals("A JanusGraph graph with the same instance id [not-unique] is already open. Might required forced shutdown.", janusGraphException.getMessage());
@@ -79,9 +80,9 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(UNIQUE_INSTANCE_ID_HOSTNAME.toStringWithoutRoot(), true);
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
-        assertEquals(graph.openManagement().getOpenInstances().size(), 1);
-        assertEquals(graph.openManagement().getOpenInstances().toArray()[0], Inet4Address.getLocalHost().getHostName());
+        final StandardJanusGraph graph = JanusGraphFactory.open(config);
+        assertEquals(1, graph.openManagement().getOpenInstances().size());
+        assertEquals(Inet4Address.getLocalHost().getHostName(), graph.openManagement().getOpenInstances().toArray()[0]);
 				graph.close();
     }
 
@@ -92,9 +93,9 @@ public class GraphDatabaseConfigurationInstanceIdTest {
         map.put(UNIQUE_INSTANCE_ID_HOSTNAME.toStringWithoutRoot(), true);
         map.put(UNIQUE_INSTANCE_ID_SUFFIX.toStringWithoutRoot(), 1);
 				final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
-        assertEquals(graph.openManagement().getOpenInstances().size(), 1);
-        assertEquals(graph.openManagement().getOpenInstances().toArray()[0], Inet4Address.getLocalHost().getHostName() + "1");
+        final StandardJanusGraph graph = JanusGraphFactory.open(config);
+        assertEquals(1, graph.openManagement().getOpenInstances().size(), 1);
+        assertEquals(Inet4Address.getLocalHost().getHostName() + "1", graph.openManagement().getOpenInstances().toArray()[0]);
 				graph.close();
     }
 }

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphBaseTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphBaseTest.java
@@ -81,12 +81,11 @@ public abstract class JanusGraphBaseTest {
         getBackend(config).clearStorage();
     }
 
-    public static Backend getBackend(WriteConfiguration config) throws BackendException {
+    public static Backend getBackend(WriteConfiguration config) {
         ModifiableConfiguration adjustedConfig = new ModifiableConfiguration(GraphDatabaseConfiguration.ROOT_NS,config.copy(), BasicConfiguration.Restriction.NONE);
         adjustedConfig.set(GraphDatabaseConfiguration.LOCK_LOCAL_MEDIATOR_GROUP, "tmp");
         adjustedConfig.set(GraphDatabaseConfiguration.UNIQUE_INSTANCE_ID, "inst");
-        Backend backend = new Backend(adjustedConfig);
-        return backend;
+        return new Backend(adjustedConfig);
     }
 
     @BeforeEach
@@ -102,7 +101,7 @@ public abstract class JanusGraphBaseTest {
     }
 
     public void open(WriteConfiguration config) {
-        graph = (StandardJanusGraph) JanusGraphFactory.open(config);
+        graph = JanusGraphFactory.open(config);
         features = graph.getConfiguration().getStoreFeatures();
         tx = graph.newTransaction();
         mgmt = graph.openManagement();

--- a/janusgraph-test/src/test/java/org/janusgraph/core/ConfiguredGraphFactoryTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/core/ConfiguredGraphFactoryTest.java
@@ -14,24 +14,26 @@
 
 package org.janusgraph.core;
 
-import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
-import org.janusgraph.graphdb.management.JanusGraphManager;
-import org.janusgraph.graphdb.management.ConfigurationManagementGraph;
-import org.janusgraph.graphdb.management.utils.ConfigurationManagementGraphNotEnabledException;
-import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
+import org.apache.commons.configuration.MapConfiguration;
+import org.apache.tinkerpop.gremlin.server.Settings;
 import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.management.ConfigurationManagementGraph;
+import org.janusgraph.graphdb.management.JanusGraphManager;
+import org.janusgraph.graphdb.management.utils.ConfigurationManagementGraphNotEnabledException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.GRAPH_NAME;
 import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
-
-import org.apache.tinkerpop.gremlin.server.Settings;
-import org.apache.commons.configuration.MapConfiguration;
-
-import java.util.Map;
-import java.util.HashMap;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.AfterEach;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConfiguredGraphFactoryTest {
     private static final JanusGraphManager gm;
@@ -40,7 +42,7 @@ public class ConfiguredGraphFactoryTest {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph = JanusGraphFactory.open(config);
         // Instantiate the ConfigurationManagementGraph Singleton
         new ConfigurationManagementGraph(graph);
     }

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ConfigurationManagementGraphTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ConfigurationManagementGraphTest.java
@@ -48,7 +48,7 @@ public class ConfigurationManagementGraphTest {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph = JanusGraphFactory.open(config);
 
         final String propertyKeyName = "Created_Using_Template";
         final Class dataType = Boolean.class;

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ManagementLoggerGraphCacheEvictionTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ManagementLoggerGraphCacheEvictionTest.java
@@ -14,22 +14,22 @@
 
 package org.janusgraph.graphdb.management;
 
-import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
-import org.janusgraph.graphdb.configuration.builder.GraphDatabaseConfigurationBuilder;
-import org.janusgraph.graphdb.database.StandardJanusGraph;
-import org.janusgraph.graphdb.database.management.ManagementSystem;
-import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.GRAPH_NAME;
-import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
-
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.server.Settings;
+import org.janusgraph.core.JanusGraphFactory;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.GRAPH_NAME;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ManagementLoggerGraphCacheEvictionTest {
 
@@ -43,7 +43,7 @@ public class ManagementLoggerGraphCacheEvictionTest {
         final Map<String, Object> map = new HashMap<>();
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph = JanusGraphFactory.open(config);
         final ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
         mgmt.evictGraphFromCache();
         mgmt.commit();
@@ -62,7 +62,7 @@ public class ManagementLoggerGraphCacheEvictionTest {
         map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
         map.put(GRAPH_NAME.toStringWithoutRoot(), "graph1");
         final MapConfiguration config = new MapConfiguration(map);
-        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfigurationBuilder().build(new CommonsConfiguration(config)));
+        final StandardJanusGraph graph = JanusGraphFactory.open(config);
         jgm.putGraph("graph1", graph);
         assertEquals("graph1", ((StandardJanusGraph) JanusGraphManager.getInstance().getGraph("graph1")).getGraphName());
 


### PR DESCRIPTION
## What is the goal of this PR?

Another round of refactoring

## What are the changes implemented in this PR?

- Backend is now initialised in JanusGraphFactory and injected in StandardJanusGraph, this is so that GraphDatabaseConfiguration stops being a factory

- inject StoreFeatures in GraphDatabaseConfiguration instead of assigning the value when calling `getBackend()` (which is now removed btw)

- `ConfiguredGraphFactory` now invokes `JanusGraphFactory` to build a graph

- removed `localConfiguration` from `GraphDatabaseConfiguration` as it was never used

- updated tests assertions (swapped actual with expected)

- updated tests to use JanusGraphFactory instead of `new StandardJanusGraph()`